### PR TITLE
CLAS-306: Addressing medium severity alertis in ZAP report.

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -152,6 +152,10 @@ const createApp = async (): Promise<express.Application> => {
     console.log(chalk.yellow(`Listening on port ${config.app.port}...`));
   });
 
+  app.use((req, res, next) => {
+    res.status(404).send("Page not found")
+  })
+
   return app;
 };
 

--- a/utils/helmetSetup.ts
+++ b/utils/helmetSetup.ts
@@ -42,18 +42,19 @@ export const helmetSetup = (app: Application): void => {
               // Type guard to check if res has locals property (Express response)
               if ('locals' in res && typeof res.locals === 'object' && res.locals !== null) {
                 const cspNonce = 'cspNonce' in res.locals ? res.locals.cspNonce : undefined;
-                return typeof cspNonce === 'string' ? `'nonce-${cspNonce}'` : "'unsafe-inline'";
+                return typeof cspNonce === 'string' ? `'nonce-${cspNonce}'` : "'self'";
               }
-              return "'unsafe-inline'";
+              return "'self'";
             }
           ],
-          styleSrc: ["'self'", "'unsafe-inline'"], // Allow inline styles if needed
+          styleSrc: ["'self'"], // Allow inline styles if needed
           fontSrc: ["'self'", "data:"], // Allow data: URIs for fonts
           imgSrc: ["'self'", "data:"], // Allow data: URIs for images
           connectSrc: ["'self'"],
           objectSrc: ["'none'"], // Restrict <object>, <embed>, and <applet> elements
           mediaSrc: ["'self'"], // Restrict media
           frameSrc: ["'none'"], // Restrict frames
+          frameAncestors: ["'none'"], // Restrict frame ancestors
           formAction: ["'self'"], // Restrict form submissions
           baseUri: ["'self'"], // Restrict base URI
           upgradeInsecureRequests: [], // Upgrade HTTP to HTTPS


### PR DESCRIPTION
[Jira ticket (if applicable)](https://dsdmoj.atlassian.net/browse/CLAS-306)

## What changed and Why?

Addressing medium severity alerts in ZAP report:
1. Removing `unsafe-inline`
2. Adding 404 handling middleware as per https://expressjs.com/en/starter/faq.html#how-do-i-handle-404-responses

Ignoring low severity alerts in ZAP report:
1. Cookie No HttpOnly Flag - this is just on the language cookie which I don't think we have much control over?
2. Cookie without SameSite Attribute - this is the sessionId cookie that gets set in the OIDC stub. localhost issue only?

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.